### PR TITLE
customized Download path with Options settings

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -16,7 +16,8 @@ const defaultOptions = {
   includeTemplate: false,
   saveAs: false,
   downloadImages: false,
-  imagePrefix: '{title}/',
+  mdClipsFolder: 'MDClips',
+  imagePrefix: '_resources/{title}/',
   disallowedChars: '[]#^'
 }
 
@@ -70,7 +71,7 @@ function getImageFilename(src, options, prependFilePath = true) {
     imagePrefix = options.title.substring(0, options.title.lastIndexOf('/') + 1) + imagePrefix;
   }
 
-  return imagePrefix + filename;
+  return options.mdClipsFolder + "/" + imagePrefix + filename;
 }
 
 // function to replace placeholder strings with article info
@@ -164,7 +165,7 @@ async function downloadMarkdown(markdown, title, tabId, imageList = {}) {
       // start the download
       const id = await browser.downloads.download({
         url: url,
-        filename: title + ".md",
+        filename: options.mdClipsFolder + "/" + title + ".md",
         saveAs: options.saveAs
       });
       // add a listener for the download completion
@@ -193,7 +194,7 @@ async function downloadMarkdown(markdown, title, tabId, imageList = {}) {
     try {
       const options = await getOptions();
       await ensureScripts(tabId);
-      const filename = generateValidFileName(title, options.disallowedChars) + ".md";
+      const filename = options.mdClipsFolder + "/" + generateValidFileName(title, options.disallowedChars) + ".md";
       const code = `downloadMarkdown("${filename}","${base64EncodeUnicode(markdown)}");`
       await browser.tabs.executeScript(tabId, {code: code});
       Object.entries(imageList).forEach(async ([src, imgfilename]) => {

--- a/options/options.html
+++ b/options/options.html
@@ -66,6 +66,13 @@
 
         <br />
 
+        <div class="textbox-container" id="mdClipsFolder">
+            <label for="mdClipsFolder">Folder inside <code>Downloads/</code> to store MarkDownload clips:</label>
+            <input type="text" name="mdClipsFolder" role="textbox" />
+        </div> 
+
+        <br />
+        
         <div class="checkbox-container">
             <input name="downloadImages" id="downloadImages" type="checkbox" />
             <label for="downloadImages">Download images alongside markdown files</label>

--- a/options/options.js
+++ b/options/options.js
@@ -1,6 +1,6 @@
 // these are the default options
 const defaultOptions = {
-    headingStyle: "setext",
+    headingStyle: "atx",
     hr: "***",
     bulletListMarker: "*",
     codeBlockStyle: "indented",
@@ -10,14 +10,14 @@ const defaultOptions = {
     linkStyle: "inlined",
     linkReferenceStyle: "full",
     imageStyle: "markdown",
-    includeTemplate: false,
-    frontmatter: "{baseURI}\n\n> {excerpt}\n\n# {title}",
-    backmatter: "",
-    title: "{title}",
+    frontmatter: "# {pageTitle}\n\n---\n\ncreated: {date:YYYY-MM-DDTHH:mm:ss} (UTC {date:Z})\ntags: #nessy \nsource: {baseURI}\n\n---\n\n> ## Excerpt\n> {excerpt}\n\n---",
+    backmatter: "---",
+    title: "{pageTitle}",
+    includeTemplate: true,
     saveAs: false,
     downloadImages: true,
     mdClipsFolder: 'MDClips',
-    imagePrefix: '_resources/{title}/',
+    imagePrefix: '_resources/{pageTitle}/',
     disallowedChars: '[]#^'
 }
 

--- a/options/options.js
+++ b/options/options.js
@@ -15,8 +15,9 @@ const defaultOptions = {
     backmatter: "",
     title: "{title}",
     saveAs: false,
-    downloadImages: false,
-    imagePrefix: '{title}/',
+    downloadImages: true,
+    mdClipsFolder: 'MDClips',
+    imagePrefix: '_resources/{title}/',
     disallowedChars: '[]#^'
 }
 
@@ -36,6 +37,7 @@ const saveOptions = e => {
         saveAs: document.querySelector("[name='saveAs']").checked,
         downloadImages: document.querySelector("[name='downloadImages']").checked,
         imagePrefix: document.querySelector("[name='imagePrefix']").value,
+        mdClipsFolder: document.querySelector("[name='mdClipsFolder']").value,
 
         headingStyle: getCheckedValue(document.querySelectorAll("input[name='headingStyle']")),
         hr: getCheckedValue(document.querySelectorAll("input[name='hr']")),
@@ -92,6 +94,7 @@ const restoreOptions = () => {
         document.querySelector("[name='saveAs']").checked = result.saveAs;
         document.querySelector("[name='downloadImages']").checked = result.downloadImages;
         document.querySelector("[name='imagePrefix']").value = result.imagePrefix;
+        document.querySelector("[name='mdClipsFolder']").value = result.mdClipsFolder;
 
         setCheckedValue(document.querySelectorAll("[name='headingStyle']"), result.headingStyle);
         setCheckedValue(document.querySelectorAll("[name='hr']"), result.hr);


### PR DESCRIPTION
Hi! I've just added the option to customize the folder inside `~/Downloads/` where MDs and images are saved. Have a look.
![2021-01-08 22 29 11 Extensions and 3 more pages - ](https://user-images.githubusercontent.com/6605974/104062062-6aca7f00-5202-11eb-81fa-10024eae6686.png)


By default the files are stored in `~/Downloads/MDClips/`, so that it's now easier to locate them and add to any MD vault later if needed.

![2021-01-08 22 26 41 MDClips (1)](https://user-images.githubusercontent.com/6605974/104062069-6ef69c80-5202-11eb-86db-130d194ec62d.png)

Linked to #41 