### PR TITLE
Add direct keyboard shortcut for Download tab as Markdown

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -575,6 +575,14 @@ async function createMenus() {
   }, () => { });
 }
 
+browser.commands.onCommand.addListener(function (command) {
+  if (command == "download_tab_as_markdown") {
+    const tab = browser.tabs.getCurrent()
+    const info = { menuItemId: "download-markdown-all" };
+    downloadMarkdownFromContext(info, tab);
+  }
+});
+
 // click handler for the context menus
 browser.contextMenus.onClicked.addListener(function (info, tab) {
   // one of the copy to clipboard commands

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -52,7 +52,13 @@
       "suggested_key": {
         "default": "Alt+Shift+M"
       }
-    }
+    },
+    "download_tab_as_markdown": {
+        "suggested_key": {
+          "default": "Ctrl+Shift+M"
+        },
+        "description": "Save current tab as Markdown"
+      }
   },
   "browser_specific_settings": {
     "gecko": {


### PR DESCRIPTION
Hi, 

I've put in a small PR to add a keyboard shortcut for downloading the current tab to markdown directly. 

Let me know if you me to make any changes. 