### PR TITLE
fix(obsidian-integration): fix chrome compatibility for url redirect.

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -785,7 +785,7 @@ async function copyMarkdownFromContext(info, tab) {
       const obsidianFolder = options.obsidianFolder;
       const { markdown } = await convertArticleToMarkdown(article, downloadImages = false);
       await browser.tabs.executeScript(tab.id, { code: `copyToClipboard(${JSON.stringify(markdown)})` });
-      document.location.href = "obsidian://advanced-uri?vault=" + obsidianVault + "&clipboard=true&mode=new&filepath=" + obsidianFolder + "/" + generateValidFileName(title)
+      await chrome.tabs.update({url: "obsidian://advanced-uri?vault=" + obsidianVault + "&clipboard=true&mode=new&filepath=" + obsidianFolder + "/" + generateValidFileName(title)});
     }
     else if(info.menuItemId == "copy-markdown-obsall") {
       const article = await getArticleFromContent(tab.id, info.menuItemId == "copy-markdown-obsall");
@@ -795,7 +795,7 @@ async function copyMarkdownFromContext(info, tab) {
       const obsidianFolder = options.obsidianFolder;
       const { markdown } = await convertArticleToMarkdown(article, downloadImages = false);
       await browser.tabs.executeScript(tab.id, { code: `copyToClipboard(${JSON.stringify(markdown)})` });
-      document.location.href = "obsidian://advanced-uri?vault=" + obsidianVault + "&clipboard=true&mode=new&filepath=" + obsidianFolder + "/" + generateValidFileName(title)
+      await browser.tabs.update({url: "obsidian://advanced-uri?vault=" + obsidianVault + "&clipboard=true&mode=new&filepath=" + obsidianFolder + "/" + generateValidFileName(title)});
     }
     else {
       const article = await getArticleFromContent(tab.id, info.menuItemId == "copy-markdown-selection");

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -116,13 +116,11 @@ More information:  <a href="https://vinzent03.github.io/obsidian-advanced-uri/">
 
         <br />
 
-        <div id="obsidianUriGroup">
-            <div class="textbox-container" id="obsidianVault">
-                <label for="obsidianVault">Obsidian Vault Name: </label>
-                <input type="text" name="obsidianVault" role="textbox" />
-                <label for="obsidianFolder">Obsidian Folder: </label>
-                <input type="text" name="obsidianFolder" role="textbox" />
-            </div>
+        <div class="textbox-container" id="obsidianVault">
+            <label for="obsidianVault">Obsidian Vault Name: </label>
+            <input type="text" name="obsidianVault" role="textbox" />
+            <label for="obsidianFolder">Obsidian Folder: </label>
+            <input type="text" name="obsidianFolder" role="textbox" />
         </div>
 
         <br />

--- a/src/shared/default-options.js
+++ b/src/shared/default-options.js
@@ -24,7 +24,7 @@ const defaultOptions = {
   turndownEscape: true,
   contextMenus: true,
   obsidianIntegration: false,
-  obsidianVault: null,
+  obsidianVault: "",
   obsidianFolder: "",
 }
 


### PR DESCRIPTION
Today i tested the obsidian in chrome, but the context menu seem not working. I've updated the background.js to use browser.tabs.update instead of document.location.href. It's working now in firefox and chrome. 