### PR TITLE
feat: copy only selectd tab URL

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -576,7 +576,11 @@ browser.commands.onCommand.addListener(function (command) {
   }
   else if (command == "copy_tab_as_markdown_link") {
     copyTabAsMarkdownLink(tab);
-  }else if (command == "copy_selection_to_obsidian") {
+  }
+  else if (command == "copy_selected_tab_as_markdown_link") {
+    copySelectedTabAsMarkdownLink(tab);
+  }
+  else if (command == "copy_selection_to_obsidian") {
     const info = { menuItemId: "copy-markdown-obsidian" };
     copyMarkdownFromContext(info, tab);
   }
@@ -602,6 +606,10 @@ browser.contextMenus.onClicked.addListener(function (info, tab) {
   // copy tab as markdown link
   else if (info.menuItemId.startsWith("copy-tab-as-markdown-link-all")) {
     copyTabAsMarkdownLinkAll(tab);
+  }
+  // copy only selected tab as markdown link
+  else if (info.menuItemId.startsWith("copy-tab-as-markdown-link-selected")) {
+    copySelectedTabAsMarkdownLink(tab);
   }
   else if (info.menuItemId.startsWith("copy-tab-as-markdown-link")) {
     copyTabAsMarkdownLink(tab);
@@ -706,6 +714,7 @@ async function getArticleFromDom(domString) {
   dom.body.querySelectorAll('pre br')?.forEach(br => {
     // we need to keep <br> tags because they are removed by Readability.js
     br.outerHTML = '<br-keep></br-keep>';
+  });
 
   dom.body.querySelectorAll('.codehilite > pre')?.forEach(codeSource => {
     if (codeSource.firstChild.nodeName !== 'CODE' && !codeSource.className.includes('language')) {
@@ -842,6 +851,36 @@ async function copyTabAsMarkdownLinkAll(tab) {
       links.push(link)
     };
     
+    const markdown = links.join(`\n`)
+    await browser.tabs.executeScript(tab.id, { code: `copyToClipboard(${JSON.stringify(markdown)})` });
+
+  }
+  catch (error) {
+    // This could happen if the extension is not allowed to run code in
+    // the page, for example if the tab is a privileged page.
+    console.error("Failed to copy as markdown link: " + error);
+  };
+}
+
+// function to copy only selected tabs as markdown links
+async function copySelectedTabAsMarkdownLink(tab) {
+  try {
+    const options = await getOptions();
+    options.frontmatter = options.backmatter = '';
+    const tabs = await browser.tabs.query({
+      currentWindow: true,
+      highlighted: true
+    });
+
+    const links = [];
+    for (const tab of tabs) {
+      await ensureScripts(tab.id);
+      const article = await getArticleFromContent(tab.id);
+      const title = await formatTitle(article);
+      const link = `${options.bulletListMarker} [${title}](${article.baseURI})`
+      links.push(link)
+    };
+
     const markdown = links.join(`\n`)
     await browser.tabs.executeScript(tab.id, { code: `copyToClipboard(${JSON.stringify(markdown)})` });
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -75,6 +75,9 @@
         "default": "Alt+Shift+L"
       },
       "description": "Copy current tab URL as Markdown link to the clipboard"
+    },
+    "copy_selected_tab_as_markdown_link": {
+      "description": "Copy selected tabs URL as Markdown link to the clipboard"
     }
   },
   "browser_specific_settings": {

--- a/src/shared/context-menus.js
+++ b/src/shared/context-menus.js
@@ -33,6 +33,12 @@ async function createMenus() {
       }, () => { });
 
       browser.contextMenus.create({
+        id: "copy-tab-as-markdown-link-selected-tab",
+        title: "Copy Selected Tab URLs as Markdown Link List",
+        contexts: ["tab"]
+      }, () => { });
+
+      browser.contextMenus.create({
         id: "tab-separator-1",
         type: "separator",
         contexts: ["tab"]
@@ -115,6 +121,11 @@ async function createMenus() {
     browser.contextMenus.create({
       id: "copy-tab-as-markdown-link-all",
       title: "Copy All Tab URLs as Markdown Link List",
+      contexts: ["all"]
+    }, () => { });
+    browser.contextMenus.create({
+      id: "copy-tab-as-markdown-link-selected",
+      title: "Copy Selected Tab URLs as Markdown Link List",
       contexts: ["all"]
     }, () => { });
   

--- a/user-guide.md
+++ b/user-guide.md
@@ -33,6 +33,9 @@ This converts the  currently selected section of the web page as Markdown and co
 ### Copy Tab URL as Markdown Link
 Copys the current tab's url and title as a Markdown link to be pasted into another Markdown document
 
+### Copy Selected Tabs as Markdown Link
+Copys all selected tabs into Markdown link to be pasted into another Markdown document
+
 ### Copy Link as Markdown
 **Only when right-clicking on a link**  
 Copies the selected link as a Markdown link to be pasted into another Markdown document


### PR DESCRIPTION
Hello :)

Maybe other will found it usefull.
I have a use case where I need to copy only the selected tabs as makrdownlink (not all tabs)
- I do not want to select pin tabs
- before that, I had to move all the tab I wanted to save into anoter window


https://user-images.githubusercontent.com/2632192/218323680-82b421c3-a8e6-4a34-a36c-83de82e7bf8b.mp4

Let me know If I can help in any other way
