### PR TITLE
feat: allow custom texts in obsidian folder name

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -797,6 +797,19 @@ async function formatMdClipsFolder(article) {
   return mdClipsFolder;
 }
 
+async function formatObsidianFolder(article) {
+  let options = await getOptions();
+
+  let obsidianFolder = '';
+  if (options.obsidianFolder) {
+    obsidianFolder = textReplace(options.obsidianFolder, article, options.disallowedChars);
+    obsidianFolder = obsidianFolder.split('/').map(s => generateValidFileName(s, options.disallowedChars)).join('/');
+    if (!obsidianFolder.endsWith('/')) obsidianFolder += '/';
+  }
+
+  return obsidianFolder;
+}
+
 // function to download markdown, triggered by context menu
 async function downloadMarkdownFromContext(info, tab) {
   await ensureScripts(tab.id);
@@ -882,20 +895,20 @@ async function copyMarkdownFromContext(info, tab) {
       const title = article.title;
       const options = await getOptions();
       const obsidianVault = options.obsidianVault;
-      const obsidianFolder = options.obsidianFolder;
+      const obsidianFolder = await formatObsidianFolder(article);
       const { markdown } = await convertArticleToMarkdown(article, downloadImages = false);
       await browser.tabs.executeScript(tab.id, { code: `copyToClipboard(${JSON.stringify(markdown)})` });
-      await chrome.tabs.update({url: "obsidian://advanced-uri?vault=" + obsidianVault + "&clipboard=true&mode=new&filepath=" + obsidianFolder + folderSeparator + generateValidFileName(title)});
+      await chrome.tabs.update({url: "obsidian://advanced-uri?vault=" + obsidianVault + "&clipboard=true&mode=new&filepath=" + obsidianFolder + generateValidFileName(title)});
     }
     else if(info.menuItemId == "copy-markdown-obsall") {
       const article = await getArticleFromContent(tab.id, info.menuItemId == "copy-markdown-obsall");
       const title = article.title;
       const options = await getOptions();
       const obsidianVault = options.obsidianVault;
-      const obsidianFolder = options.obsidianFolder;
+      const obsidianFolder = await formatObsidianFolder(article);
       const { markdown } = await convertArticleToMarkdown(article, downloadImages = false);
       await browser.tabs.executeScript(tab.id, { code: `copyToClipboard(${JSON.stringify(markdown)})` });
-      await browser.tabs.update({url: "obsidian://advanced-uri?vault=" + obsidianVault + "&clipboard=true&mode=new&filepath=" + obsidianFolder + folderSeparator + generateValidFileName(title)});
+      await browser.tabs.update({url: "obsidian://advanced-uri?vault=" + obsidianVault + "&clipboard=true&mode=new&filepath=" + obsidianFolder + generateValidFileName(title)});
     }
     else {
       const article = await getArticleFromContent(tab.id, info.menuItemId == "copy-markdown-selection");

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -706,6 +706,7 @@ async function getArticleFromDom(domString) {
   dom.body.querySelectorAll('pre br')?.forEach(br => {
     // we need to keep <br> tags because they are removed by Readability.js
     br.outerHTML = '<br-keep></br-keep>';
+  });
 
   dom.body.querySelectorAll('.codehilite > pre')?.forEach(codeSource => {
     if (codeSource.firstChild.nodeName !== 'CODE' && !codeSource.className.includes('language')) {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -75,6 +75,12 @@
         "default": "Alt+Shift+L"
       },
       "description": "Copy current tab URL as Markdown link to the clipboard"
+    },
+    "copy_selection_to_obsidian": {
+      "description": "Copy current selection as Markdown to Obsidian"
+    },
+    "copy_tab_to_obsidian": {
+      "description": "Copy current tab as Markdown to Obsidian"
     }
   },
   "browser_specific_settings": {


### PR DESCRIPTION
Hi, first off, I want to say thank you for this fantastic extension.

This PR does the following;
- Allow users to include custom text such like `{date:YYYY-MM-DD}/` in their `Obsidian Folder Name` setting.
- Enable users to bind keyboard shortcuts to Obsidian-related commands. (ref #222)
- Fix a minor syntax error introduced around #200.
