### PR TITLE
support MathJax 3

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -692,6 +692,22 @@ async function getArticleFromDom(domString) {
     });
   });
 
+  dom.body.querySelectorAll('[markdownload-latex]')?.forEach(mathJax3Node =>  {
+    const tex = mathJax3Node.getAttribute('markdownload-latex')
+    const display = mathJax3Node.getAttribute('display')
+    const inline = !(display && display === 'true')
+
+    const mathNode = document.createElement(inline ? "i" : "p")
+    mathNode.textContent = tex;
+    mathJax3Node.parentNode.insertBefore(mathNode, mathJax3Node.nextSibling)
+    mathJax3Node.parentNode.removeChild(mathJax3Node)
+
+    storeMathInfo(mathNode, {
+      tex: tex,
+      inline: inline
+    });
+  });
+
   dom.body.querySelectorAll('.katex-mathml')?.forEach(kaTeXNode => {
     storeMathInfo(kaTeXNode, {
       tex: kaTeXNode.querySelector('annotation').textContent,

--- a/src/contentScript/contentScript.js
+++ b/src/contentScript/contentScript.js
@@ -150,3 +150,9 @@ function downloadImage(filename, url) {
     }
     */
 }
+
+(function loadPageContextScript(){
+    var s = document.createElement('script');
+    s.src = browser.runtime.getURL('contentScript/pageContext.js');
+    (document.head||document.documentElement).appendChild(s);
+})()

--- a/src/contentScript/pageContext.js
+++ b/src/contentScript/pageContext.js
@@ -1,0 +1,11 @@
+function addLatexToMathJax3()
+{
+    if (!MathJax?.startup?.document?.math)
+        return
+
+    for (math of MathJax.startup.document.math)
+    {
+        math.typesetRoot.setAttribute("markdownload-latex", math.math)
+    }
+}
+addLatexToMathJax3()


### PR DESCRIPTION
MathJax 3 no longer emit latex to html. We need access to the page's MathJax instance to acquire the original latex.