### PR TITLE
Fix stripping of headings

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -671,6 +671,7 @@ async function getArticleFromDom(domString) {
   // parse the dom
   const parser = new DOMParser();
   const dom = parser.parseFromString(domString, "text/html");
+
   if (dom.documentElement.nodeName == "parsererror") {
     console.error("error while parsing");
   }
@@ -722,8 +723,16 @@ async function getArticleFromDom(domString) {
     }
   });
 
+  dom.body.querySelectorAll('h1, h2, h3, h4, h5, h6')?.forEach(header => {
+    // Readability.js will strip out headings from the dom if certain words appear in their className
+    // See: https://github.com/mozilla/readability/issues/807  
+    header.className = '';
+    header.outerHTML = header.outerHTML;  
+  });
+
   // simplify the dom into an article
   const article = new Readability(dom).parse();
+
   // get the base uri from the dom and attach it as important article info
   article.baseURI = dom.baseURI;
   // also grab the page title


### PR DESCRIPTION
Hey, first of all, thank you very much for this extension 🙏, I'm using it daily with Obsidian. 

I noticed that all headings were missing in Substack articles, and it seems to be related with Readability removing elements whose class names contains certain words: https://github.com/mozilla/readability/issues/807

<img width="1022" alt="Error" src="https://github.com/deathau/markdownload/assets/2279003/b4a5f34c-dc3a-4509-a544-2fe902d2867b">

I tried removing the classes of all headings, and it does the trick of preserving those elements in the final article:
<img width="1016" alt="Screen Shot 2023-09-20 at 23 20 38" src="https://github.com/deathau/markdownload/assets/2279003/df9d1b63-dc90-49aa-8713-482aacc96825">
