### PR TITLE
Resolve Obsidian Filename Determination Issue in background.js

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -955,7 +955,7 @@ async function copyMarkdownFromContext(info, tab) {
     }
     else if(info.menuItemId == "copy-markdown-obsidian") {
       const article = await getArticleFromContent(tab.id, info.menuItemId == "copy-markdown-obsidian");
-      const title = article.title;
+      const title = await formatTitle(article);
       const options = await getOptions();
       const obsidianVault = options.obsidianVault;
       const obsidianFolder = await formatObsidianFolder(article);

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -965,7 +965,7 @@ async function copyMarkdownFromContext(info, tab) {
     }
     else if(info.menuItemId == "copy-markdown-obsall") {
       const article = await getArticleFromContent(tab.id, info.menuItemId == "copy-markdown-obsall");
-      const title = article.title;
+      const title = await formatTitle(article);
       const options = await getOptions();
       const obsidianVault = options.obsidianVault;
       const obsidianFolder = await formatObsidianFolder(article);


### PR DESCRIPTION
## Description
This pull request addresses the Obsidian integration issue related to filename determination in the `background.js` file. The problem was identified in the use of `article.title`, which did not adhere to the "Template for title/filename" setting. The fix involves replacing `article.title` with `await formatTitle(article)`, ensuring proper alignment with user configuration preferences.

## Changes Made
- Modified Obsidian integration logic in `background.js`: replaced `article.title` with `await formatTitle(article)`.

## Issue Reference
Closes #289