### PR TITLE
Prevent Readability.js from removing the <html> element if it has a class attribute with specific values 

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -746,6 +746,12 @@ async function getArticleFromDom(domString) {
     header.outerHTML = header.outerHTML;  
   });
 
+  // Prevent Readability from removing the <html> element if has a 'class' attribute
+  // which matches removal criteria.
+  // Note: The document element is guaranteed to be the HTML tag because the 'text/html'
+  // mime type was used when the DOM was created.
+  dom.documentElement.removeAttribute('class')
+
   // simplify the dom into an article
   const article = new Readability(dom).parse();
 


### PR DESCRIPTION
For web pages which have a HTML root tag with a `class` attribute whose value matches the removal criteria of `Readability.js` 

* the pageTitle is undefined
* baseURI point to chrome-extension://nghfdnngoejlhedogdpikdlkmdfoojii/_generated_background_page.html rather than the actual web page
* local links are incorrect

The problem is that `Readability.ls` removes the `<html>` root tag, as a consequence, uses the wrong urls. Also, `Markdownload` loses access to the page meta-data.

This pull request fixes issue #260  by removing the class attribute from the `<html>` root tag.

Following sites mentioned in issue #260 work correctly with this fix:
*  https://learn.microsoft.com/en-us/dotnet/maui/android/deployment/publish-cli?view=net-maui-7.0 - reported by @arkadym
*  https://www.australianbookreview.com.au/about/author/4411-davidhansen - reported by @tullyhansen

Note: This does *not* fix issue #201 !