### PR TITLE
Make sure the document processed in background.js has a title element.

### DIFF
--- a/src/contentScript/contentScript.js
+++ b/src/contentScript/contentScript.js
@@ -4,12 +4,13 @@ function notifyExtension() {
 }
 
 function getHTMLOfDocument() {
-    // make sure a title tag exists so that pageTitle os not empty
-    if (!document.title) {
+    // make sure a title tag exists so that pageTitle is not empty and
+    // a filename can be genarated.
+    if (document.head.getElementsByTagName('title') == 0) {
         let titleEl = document.createElement('title');
+        // prepate a good default text (the text displayed in the window title)
+        titleEl.innerText = document.title;
         document.head.append(titleEl);
-        // prepate the default text
-        titleEl.innerText = window.location.hostname + "╱"+ window.location.pathname.replace('/','╱')
     }
 
     // if the document doesn't have a "base" element make one

--- a/src/contentScript/contentScript.js
+++ b/src/contentScript/contentScript.js
@@ -4,6 +4,14 @@ function notifyExtension() {
 }
 
 function getHTMLOfDocument() {
+    // make sure a title tag exists so that pageTitle os not empty
+    if (!document.title) {
+        let titleEl = document.createElement('title');
+        document.head.append(titleEl);
+        // prepate the default text
+        titleEl.innerText = window.location.hostname + "╱"+ window.location.pathname.replace('/','╱')
+    }
+
     // if the document doesn't have a "base" element make one
     // this allows the DOM parser in future steps to fix relative uris
     let baseEl = document.createElement('base');

--- a/src/contentScript/contentScript.js
+++ b/src/contentScript/contentScript.js
@@ -6,7 +6,7 @@ function notifyExtension() {
 function getHTMLOfDocument() {
     // make sure a title tag exists so that pageTitle is not empty and
     // a filename can be genarated.
-    if (document.head.getElementsByTagName('title') == 0) {
+    if (document.head.getElementsByTagName('title').length == 0) {
         let titleEl = document.createElement('title');
         // prepate a good default text (the text displayed in the window title)
         titleEl.innerText = document.title;


### PR DESCRIPTION
This addresses issue #310: which describes a download failure for a specific website, because `pageTitle` is empty.

The proposed fix here makes sure that the HTML document processed in `background.js` has a proper `<title>` tag, so that `pageTitle` can be populated.

Note: Despite a missing `<title>` tag browsers manage to provide a useful window title. Hence the  best place to fix this issue seems to be  `contentScript.js` because it is run in the context of the original HTML page