### PR TITLE
Fixed unreadable code blocks.

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -185,7 +185,11 @@ function turndown(content, options, article) {
 
   // handle <pre> as code blocks
   turndownService.addRule('pre', {
-    filter: (node, tdopts) => node.nodeName == 'PRE' && (!node.firstChild || node.firstChild.nodeName != 'CODE'),
+    filter: (node, tdopts) => {
+      return node.nodeName == 'PRE'
+             && (!node.firstChild || node.firstChild.nodeName != 'CODE')
+             && !node.querySelector('img');
+    },
     replacement: (content, node, tdopts) => {
       return convertToFencedCodeBlock(node, tdopts);
     }

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -147,26 +147,20 @@ function turndown(content, options, article) {
     const langMatch = node.id?.match(/code-lang-(.+)/);
     const language = langMatch?.length > 0 ? langMatch[1] : '';
 
-    var code;
+    const code = node.innerText;
 
-    if (language) {
-      code = node.innerText;
-    } else {
-      code = node.innerHTML;
-    }
+    const fenceChar = options.fence.charAt(0);
+    let fenceSize = 3;
+    const fenceInCodeRegex = new RegExp('^' + fenceChar + '{3,}', 'gm');
 
-    var fenceChar = options.fence.charAt(0);
-    var fenceSize = 3;
-    var fenceInCodeRegex = new RegExp('^' + fenceChar + '{3,}', 'gm');
-
-    var match;
+    let match;
     while ((match = fenceInCodeRegex.exec(code))) {
       if (match[0].length >= fenceSize) {
         fenceSize = match[0].length + 1;
       }
     }
 
-    var fence = repeat(fenceChar, fenceSize);
+    const fence = repeat(fenceChar, fenceSize);
 
     return (
       '\n\n' + fence + language + '\n' +

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -150,11 +150,7 @@ function turndown(content, options, article) {
     var code;
 
     if (language) {
-      var div = document.createElement('div');
-      document.body.appendChild(div);
-      div.appendChild(node);
       code = node.innerText;
-      div.remove();
     } else {
       code = node.innerHTML;
     }
@@ -206,7 +202,7 @@ function turndown(content, options, article) {
 
   // strip out non-printing special characters which CodeMirror displays as a red dot
   // see: https://codemirror.net/doc/manual.html#option_specialChars
-  markdown = markdown.replace(/[\u0000-\u0009\u000b\u000c\u000e-\u001f\u007f-\u009f\u00ad\u061c\u200b-\u200f\u2028\u2029\ufeff\ufff9-\ufffc]/g, '');
+  markdown = markdown.replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f\u00ad\u061c\u200b-\u200f\u2028\u2029\ufeff\ufff9-\ufffc]/g, '');
   
   return { markdown: markdown, imageList: imageList };
 }


### PR DESCRIPTION
This fixes issue #191, #272, and most likely #278

The ugly flattened rendering of code blocks is caused by the removal of the `<code>` element from its owning `<pre>`.  `code.innerText` loses all spacings and linefeeds. In addition, a second fix was needed because all tab characters `\t` were stripped in the `turndown` function (background.js). This caused code blocks to lose all indents.

This part of the fix addresses the site:
- https://threedots.tech/post/making-games-in-go/ - reported by @setanarut. 

The links to Medium articles are a different story. The code in these articles are **not** proper code blocks.
They look like this:
```html
<pre>$ curl https://<span class="hljs-built_in">get</span>.docker.<span class="hljs-keyword">com</span> | <span class="hljs-keyword">sh</span></pre>
```
The code has been pre-processed, and then stuck directly under a `<pre>` tag.  No `<code>`  element present.

This is addressed by the second part of the fix which returns the content of `<pre>` elements as text rather than html. However, there is **no** syntax highlighting due to the missing `<code>`  element.

This addresses:
- https://beingpax.medium.com/how-to-use-obsidian-as-a-task-manager-6643bbcb1911 - reported by @Smitty010 
- https://itnext.io/docker-tips-about-none-images-39fb34b20bc5 - reported by @a-ski 
- https://medium.com/@dchouhan93/automating-container-instances-draining-in-amazon-ecs-using-lambda-and-asg-lifecycle-hook-383c8f3557f7 reported by @akhiljalagam 

#278 is most likely fixed too, but I were not able to test this.




